### PR TITLE
Fixed usage of language filter in streamer

### DIFF
--- a/streamer/streamer.py
+++ b/streamer/streamer.py
@@ -236,7 +236,7 @@ def setStreamer():
                 elif len(KW[1]) == 0 or KW[1] == False or KW[1] == None:
                     stream.statuses.filter(track=KW[0]) #Keywords, no language                                   
                 else:
-                    stream.statuses.filter(track=KW[0], languages=KW[1]) #Keywords + language
+                    stream.statuses.filter(track=KW[0], language=KW[1]) #Keywords + language
                     
             
         except: #Error handling


### PR DESCRIPTION
Correct usage is <language='en'> instead of <languages='en'>
Can also be used with comma-separated list